### PR TITLE
基準パスを変更

### DIFF
--- a/plugin.accessBySSL.php
+++ b/plugin.accessBySSL.php
@@ -6,7 +6,7 @@
  * プラグイン設定: &ids=書き換えるドキュメントID(コンマ区切り);int;1 &append=追加する文字列;text;https://;
  */
 
-include_once $modx->config['rb_base_dir'] . "plugins/accessBySSL/accessBySSL.inc.php";
+include_once $modx->config['base_path'] . "assets/plugins/accessBySSL/accessBySSL.inc.php";
 $e = &$modx->Event;
 
 switch($e->name) {


### PR DESCRIPTION
rb_base_dirはプラグインディレクトリとは無関係のディレクトリ階層に変更できるため
